### PR TITLE
don't unnecessarily depend on concrete classes

### DIFF
--- a/src/class_not_found/core.clj
+++ b/src/class_not_found/core.clj
@@ -1,6 +1,5 @@
 (ns class-not-found.core
   (:gen-class)
-  (:require record-holder.def)
-  (:import record_holder.def.ParallelAggregator))
+  (:require record-holder.def))
 
-(defn -main [& _] (println (ParallelAggregator.)))
+(defn -main [& _] (println (record-holder.def/->ParallelAggregator)))


### PR DESCRIPTION
It is bad coupling to depend on concrete classes like this.  I am working on https://dev.clojure.org/jira/browse/CLJ-1544 and will add more details there.